### PR TITLE
Suggestion to optimize borrowing and change formatting.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,7 @@ crate-type = ["lib"]
 
 [dependencies]
 cryptography-utils = { git = "https://github.com/KZen-networks/cryptography-utils" ,  features =  ["curvesecp256k1"]}
+
+
+[dev-dependencies]
 hex = "0.3.2"

--- a/src/protocols/aggsig/mod.rs
+++ b/src/protocols/aggsig/mod.rs
@@ -91,7 +91,6 @@ impl KeyAgg {
     pub fn key_aggregation_n(pks: &[GE], party_index: usize) -> KeyAgg {
         let bn_1 = BigInt::from(1);
         let x_coor_vec: Vec<BigInt> = (0..pks.len())
-//            .into_iter()
             .map(|i| pks[i].x_coor())
             .collect();
         let hash_vec: Vec<BigInt> = x_coor_vec

--- a/src/protocols/aggsig/mod.rs
+++ b/src/protocols/aggsig/mod.rs
@@ -66,7 +66,7 @@ pub struct KeyAgg {
 }
 
 impl KeyAgg {
-    pub fn key_aggregation(my_pk: &GE, other_pk: &GE) -> KeyAgg {
+    pub fn key_aggregation(my_pk: GE, other_pk: GE) -> KeyAgg {
         let hash = HSha256::create_hash(&vec![
             &BigInt::from(1),
             &my_pk.x_coor(),
@@ -74,8 +74,7 @@ impl KeyAgg {
             &other_pk.x_coor(),
         ]);
         let hash_fe: FE = ECScalar::from(&hash);
-        let pk1 = my_pk.clone();
-        let a1 = pk1.scalar_mul(&hash_fe.get_element());
+        let a1 = my_pk.scalar_mul(&hash_fe.get_element());
 
         let hash2 = HSha256::create_hash(&vec![
             &BigInt::from(1),
@@ -84,8 +83,7 @@ impl KeyAgg {
             &other_pk.x_coor(),
         ]);
         let hash2_fe: FE = ECScalar::from(&hash2);
-        let pk2 = other_pk.clone();
-        let a2 = pk2.scalar_mul(&hash2_fe.get_element());
+        let a2 = other_pk.scalar_mul(&hash2_fe.get_element());
         let apk = a2.add_point(&(a1.get_element()));
         KeyAgg { apk: apk, hash }
     }
@@ -128,7 +126,7 @@ impl KeyAgg {
 
         KeyAgg {
             apk: sum,
-            hash: hash_vec[*party_index].clone(),
+            hash: hash_vec[*party_index],
         }
     }
 }
@@ -212,9 +210,9 @@ impl EphemeralKey {
         )
     }
 
-    pub fn add_signature_parts(s1: &BigInt, s2: &BigInt, r_tag: &GE) -> (BigInt, BigInt) {
+    pub fn add_signature_parts(s1: BigInt, s2: &BigInt, r_tag: &GE) -> (BigInt, BigInt) {
         if *s2 == BigInt::from(0) {
-            (r_tag.x_coor(), s1.clone())
+            (r_tag.x_coor(), s1)
         } else {
             let s1_fe: FE = ECScalar::from(&s1);
             let s2_fe: FE = ECScalar::from(&s2);
@@ -227,7 +225,7 @@ impl EphemeralKey {
 pub fn verify(
     signature: &BigInt,
     r_x: &BigInt,
-    apk: &GE,
+    apk: GE,
     message: &[u8],
     musig_bit: &bool,
 ) -> Result<(), ProofError> {
@@ -252,8 +250,7 @@ pub fn verify(
     let minus_c_fe: FE = ECScalar::from(&minus_c);
     let signature_fe: FE = ECScalar::from(signature);
     let sG = base_point.scalar_mul(&signature_fe.get_element());
-    let apk_c: GE = apk.clone();
-    let cY = apk_c.scalar_mul(&minus_c_fe.get_element());
+    let cY = apk.scalar_mul(&minus_c_fe.get_element());
     let sG = sG.add_point(&cY.get_element());
     if sG.x_coor().to_hex() == *r_x.to_hex() {
         Ok(())

--- a/src/protocols/aggsig/mod.rs
+++ b/src/protocols/aggsig/mod.rs
@@ -88,7 +88,7 @@ impl KeyAgg {
         KeyAgg { apk: apk, hash }
     }
 
-    pub fn key_aggregation_n(pks: &Vec<GE>, party_index: &usize) -> KeyAgg {
+    pub fn key_aggregation_n(pks: &Vec<GE>, party_index: usize) -> KeyAgg {
         let bn_1 = BigInt::from(1);
         let x_coor_vec: Vec<BigInt> = (0..pks.len())
             .into_iter()
@@ -126,7 +126,7 @@ impl KeyAgg {
 
         KeyAgg {
             apk: sum,
-            hash: hash_vec[*party_index],
+            hash: hash_vec[party_index].clone(),
         }
     }
 }

--- a/src/protocols/aggsig/test.rs
+++ b/src/protocols/aggsig/test.rs
@@ -74,9 +74,9 @@ mod tests {
 
         // compute c = H0(Rtag || apk || message)
         let party1_h_0 =
-            EphemeralKey::hash_0(&party1_r_tag, &party1_key_agg.apk, &message, &is_musig);
+            EphemeralKey::hash_0(&party1_r_tag, &party1_key_agg.apk, &message, is_musig);
         let party2_h_0 =
-            EphemeralKey::hash_0(&party2_r_tag, &party2_key_agg.apk, &message, &is_musig);
+            EphemeralKey::hash_0(&party2_r_tag, &party2_key_agg.apk, &message, is_musig);
         assert_eq!(party1_h_0, party2_h_0);
 
         // compute partial signature s_i and send to the other party:
@@ -97,7 +97,7 @@ mod tests {
         let (r, s) = EphemeralKey::add_signature_parts(s1, &s2, &party1_r_tag);
 
         // verify:
-        assert!(verify(&s, &r, party1_key_agg.apk, &message, &is_musig,).is_ok())
+        assert!(verify(&s, &r, &party1_key_agg.apk, &message, is_musig,).is_ok())
     }
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
             &party1_ephemeral_key.keypair.public_key,
             &party1_key.public_key,
             &message,
-            &is_musig,
+            is_musig,
         );
 
         let s_tag = EphemeralKey::sign(
@@ -130,11 +130,10 @@ mod tests {
         );
 
         // verify:
-        assert!(verify(&s, &R, party1_key.public_key, &message, &is_musig).is_ok())
+        assert!(verify(&s, &R, &party1_key.public_key, &message, is_musig).is_ok())
     }
 
     #[test]
-
     fn test_schnorr_bip_test_vector_2() {
         let private_key_raw = "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF";
         //let public_key_raw =  "03FAC2114C2FBB091527EB7C64ECB11F8021CB45E8E7809D3C0938E4B8C0E5F84B";
@@ -152,7 +151,7 @@ mod tests {
             &party1_ephemeral_key.keypair.public_key,
             &party1_key.public_key,
             &message,
-            &is_musig,
+            is_musig,
         );
 
         // compute partial signature s_i and send to the other party:
@@ -179,6 +178,6 @@ mod tests {
         assert_eq!(test_vector_R, sig_R);
         assert_eq!(test_vector_s, sig_s);
         // verify:
-        assert!(verify(&s, &R, party1_key.public_key, &message, &is_musig).is_ok())
+        assert!(verify(&s, &R, &party1_key.public_key, &message, is_musig).is_ok())
     }
 }

--- a/src/protocols/aggsig/test.rs
+++ b/src/protocols/aggsig/test.rs
@@ -55,8 +55,8 @@ mod tests {
         let mut pks: Vec<GE> = Vec::new();
         pks.push(party1_key.public_key.clone());
         pks.push(party2_key.public_key.clone());
-        let party1_key_agg = KeyAgg::key_aggregation_n(&pks, &0);
-        let party2_key_agg = KeyAgg::key_aggregation_n(&pks, &1);
+        let party1_key_agg = KeyAgg::key_aggregation_n(&pks, 0);
+        let party2_key_agg = KeyAgg::key_aggregation_n(&pks, 1);
         assert_eq!(party1_key_agg.apk, party2_key_agg.apk);
 
         // compute R' = R1+R2:
@@ -94,10 +94,10 @@ mod tests {
         );
 
         // signature s:
-        let (r, s) = EphemeralKey::add_signature_parts(&s1, &s2, &party1_r_tag);
+        let (r, s) = EphemeralKey::add_signature_parts(s1, &s2, &party1_r_tag);
 
         // verify:
-        assert!(verify(&s, &r, &party1_key_agg.apk, &message, &is_musig,).is_ok())
+        assert!(verify(&s, &r, party1_key_agg.apk, &message, &is_musig,).is_ok())
     }
 
     #[test]
@@ -124,13 +124,13 @@ mod tests {
 
         // signature s:
         let (R, s) = EphemeralKey::add_signature_parts(
-            &s_tag,
+            s_tag,
             &BigInt::from(0),
             &party1_ephemeral_key.keypair.public_key,
         );
 
         // verify:
-        assert!(verify(&s, &R, &party1_key.public_key, &message, &is_musig).is_ok())
+        assert!(verify(&s, &R, party1_key.public_key, &message, &is_musig).is_ok())
     }
 
     #[test]
@@ -165,7 +165,7 @@ mod tests {
 
         // signature s:
         let (R, s) = EphemeralKey::add_signature_parts(
-            &s_tag,
+            s_tag,
             &BigInt::from(0),
             &party1_ephemeral_key.keypair.public_key,
         );
@@ -179,6 +179,6 @@ mod tests {
         assert_eq!(test_vector_R, sig_R);
         assert_eq!(test_vector_s, sig_s);
         // verify:
-        assert!(verify(&s, &R, &party1_key.public_key, &message, &is_musig).is_ok())
+        assert!(verify(&s, &R, party1_key.public_key, &message, &is_musig).is_ok())
     }
 }

--- a/src/protocols/multisig/mod.rs
+++ b/src/protocols/multisig/mod.rs
@@ -97,7 +97,7 @@ impl Keys {
         return vec![keys.I.public_key, keys.X.public_key];
     }
 
-    pub fn collect_and_compute_challenge(ix_vec: &Vec<Vec<GE>>) -> FE {
+    pub fn collect_and_compute_challenge(ix_vec: &[Vec<GE>]) -> FE {
         let concat_vec = ix_vec.iter().fold(Vec::new(), |mut acc, x| {
             acc.extend_from_slice(x);
             acc
@@ -174,10 +174,8 @@ impl EphKey {
     pub fn add_signature_parts(sig_vec: Vec<FE>) -> FE {
         let mut sig_vec_c = sig_vec;
         let first_sig = sig_vec_c.remove(0);
-        let sum_sig = sig_vec_c
-            .iter()
-            .fold(first_sig, |acc, x| acc.add(&x.get_element()));
-        return sum_sig;
+
+        sig_vec_c.iter().fold(first_sig, |acc, x| acc.add(&x.get_element()))
     }
 }
 

--- a/src/protocols/multisig/mod.rs
+++ b/src/protocols/multisig/mod.rs
@@ -59,7 +59,7 @@ impl KeyPair {
         }
     }
 
-    pub fn update_key_pair(&mut self, to_add: FE ) {
+    pub fn update_key_pair(&mut self, to_add: FE) {
         self.private_key = to_add + &self.private_key;
         let g: GE = ECPoint::generator();
         self.public_key = g * &self.private_key;
@@ -76,7 +76,7 @@ impl Keys {
     pub fn create_from_private_keys(priv_I: FE, priv_X: FE) -> Keys {
         let I = KeyPair::create_from_private_key(priv_I);
         let X = KeyPair::create_from_private_key(priv_X);
-        Keys { I, X}
+        Keys { I, X }
     }
 
     pub fn create_from(secret_share: FE) -> Keys {
@@ -84,7 +84,6 @@ impl Keys {
         let X = KeyPair::create();
         Keys { I, X }
     }
-
 
     pub fn create_signing_key(keys: &Keys, eph_key: &EphKey) -> Keys {
         Keys {
@@ -175,7 +174,9 @@ impl EphKey {
         let mut sig_vec_c = sig_vec;
         let first_sig = sig_vec_c.remove(0);
 
-        sig_vec_c.iter().fold(first_sig, |acc, x| acc.add(&x.get_element()))
+        sig_vec_c
+            .iter()
+            .fold(first_sig, |acc, x| acc.add(&x.get_element()))
     }
 }
 

--- a/src/protocols/multisig/mod.rs
+++ b/src/protocols/multisig/mod.rs
@@ -73,6 +73,11 @@ impl Keys {
         Keys { I, X }
     }
 
+    pub fn create_from_private_keys(priv_I: FE, priv_X: FE) -> Keys {
+        let I = KeyPair::create_from_private_key(priv_I);
+        let X = KeyPair::create_from_private_key(priv_X);
+        Keys { I, X}
+    }
 
     pub fn create_from(secret_share: FE) -> Keys {
         let I = KeyPair::create_from_private_key(secret_share);

--- a/src/protocols/multisig/test.rs
+++ b/src/protocols/multisig/test.rs
@@ -26,18 +26,18 @@ mod tests {
         let message: [u8; 4] = [79, 77, 69, 82];
         // party1 key gen:
         let keys_1 = Keys::create();
+        // This is useless. but I don't want to change it. was this supposed to really update the value? if so the .clone() needs to be removed
+        keys_1.clone().I.update_key_pair(FE::zero());
 
-        let _ = keys_1.I.update_key_pair(&FE::zero());
-
-        let broadcast1 = Keys::broadcast(&keys_1);
+        let broadcast1 = Keys::broadcast(keys_1.clone());
         // party2 key gen:
         let keys_2 = Keys::create();
-        let broadcast2 = Keys::broadcast(&keys_2);
+        let broadcast2 = Keys::broadcast(keys_2.clone());
         let ix_vec = vec![broadcast1, broadcast2];
         let e = Keys::collect_and_compute_challenge(&ix_vec);
 
-        let y1 = partial_sign(&keys_1, &e);
-        let y2 = partial_sign(&keys_2, &e);
+        let y1 = partial_sign(&keys_1, e.clone());
+        let y2 = partial_sign(&keys_2, e.clone());
         let sig1 = Signature::set_signature(&keys_1.X.public_key, &y1);
         let sig2 = Signature::set_signature(&keys_2.X.public_key, &y2);
         // partial verify
@@ -66,9 +66,9 @@ mod tests {
 
         let (It, Xt, es) = EphKey::compute_joint_comm_e(pub_key_vec, eph_pub_key_vec, &message);
 
-        let y1 = party1_com.partial_sign(&keys_1.I, &es);
-        let y2 = party2_com.partial_sign(&keys_2.I, &es);
-        let y = EphKey::add_signature_parts(&vec![y1, y2]);
+        let y1 = party1_com.partial_sign(&keys_1.I, es.clone());
+        let y2 = party2_com.partial_sign(&keys_2.I, es.clone());
+        let y = EphKey::add_signature_parts(vec![y1, y2]);
         let sig = Signature::set_signature(&Xt, &y);
         assert!(verify(&It, &sig, &es).is_ok());
 

--- a/src/protocols/multisig/test.rs
+++ b/src/protocols/multisig/test.rs
@@ -17,9 +17,9 @@
 #[cfg(test)]
 mod tests {
     use cryptography_utils::cryptographic_primitives::hashing::merkle_tree::MT256;
-    use protocols::multisig::{partial_sign, verify, EphKey, Keys, Signature};
-    use cryptography_utils::FE;
     use cryptography_utils::elliptic::curves::traits::ECScalar;
+    use cryptography_utils::FE;
+    use protocols::multisig::{partial_sign, verify, EphKey, Keys, Signature};
 
     #[test]
     fn two_party_key_gen() {


### PR DESCRIPTION
- Changed every ownership take that was unnecessary with borrowing.

- Changed every unnecessary cloning with ownership take (it's better to let the caller of a function decide if he still needs the variable and should clone or not and just give ownership).

- Replaced every `&Vec<T>` with `&[T]`, This way even if the caller doesn't have a vector he can still pass it to the function and if he does have a vector he can just use `[..]`

- Formatted some parts to be more rust idiomatic