### PR TITLE
modifications for Zilliqa-Schnorr multi-party wrapper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,18 @@ pub enum Error {
     InvalidCom,
     InvalidSig,
 }
+
+use std::fmt;
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,"{}", &self)
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        "Schnorr Error"
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,5 @@ impl fmt::Display for Error {
 }
 
 impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        "Schnorr Error"
-    }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,8 @@ use std::fmt;
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"{}", &self)
+        write!(f, "{}", &self)
     }
 }
 
-impl std::error::Error for Error {
-}
-
+impl std::error::Error for Error {}

--- a/src/protocols/thresholdsig/zilliqa_schnorr.rs
+++ b/src/protocols/thresholdsig/zilliqa_schnorr.rs
@@ -28,8 +28,8 @@ use curv::cryptographic_primitives::commitments::hash_commitment::HashCommitment
 use curv::cryptographic_primitives::commitments::traits::Commitment;
 use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
 use curv::cryptographic_primitives::hashing::traits::Hash;
-use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
-use curv::{BigInt, FE, GE};
+pub use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
+pub use curv::{BigInt, FE, GE};
 
 const SECURITY: usize = 256;
 

--- a/src/protocols/thresholdsig/zilliqa_schnorr.rs
+++ b/src/protocols/thresholdsig/zilliqa_schnorr.rs
@@ -24,13 +24,13 @@ use curv::arithmetic::traits::*;
 
 use curv::elliptic::curves::traits::*;
 
+pub use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::commitments::hash_commitment::HashCommitment;
 use curv::cryptographic_primitives::commitments::traits::Commitment;
 use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
 use curv::cryptographic_primitives::hashing::traits::Hash;
 pub use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 pub use curv::{BigInt, FE, GE};
-pub use curv::arithmetic::traits::Converter;
 
 const SECURITY: usize = 256;
 
@@ -55,15 +55,14 @@ pub struct KeyGenBroadcastMessage2 {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyGenMessage3 {
     pub vss_scheme: VerifiableSS,
-    pub secret_share: FE,  // different per party, thus not a broadcast message
+    pub secret_share: FE, // different per party, thus not a broadcast message
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SignMessage1 {
     pub message: BigInt,
-    pub local_sig: LocalSig,  // different per party, thus not a broadcast message
+    pub local_sig: LocalSig,
 }
-
 
 #[derive(Debug)]
 pub struct Parameters {

--- a/src/protocols/thresholdsig/zilliqa_schnorr.rs
+++ b/src/protocols/thresholdsig/zilliqa_schnorr.rs
@@ -33,19 +33,28 @@ use curv::{BigInt, FE, GE};
 
 const SECURITY: usize = 256;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Keys {
     pub u_i: FE,
     pub y_i: GE,
     pub party_index: usize,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyGenBroadcastMessage1 {
     com: BigInt,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KeyGenBroadcastMessage2 {
     pub y_i: GE,
     pub blind_factor: BigInt,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KeyGenMessage3 {
+    pub vss_scheme: VerifiableSS,
+    pub secret_share: FE,  // different per party, thus not a broadcast message
 }
 
 #[derive(Debug)]
@@ -53,7 +62,8 @@ pub struct Parameters {
     pub threshold: usize,   //t
     pub share_count: usize, //n
 }
-#[derive(Clone, Serialize, Deserialize)]
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SharedKeys {
     pub y: GE,
     pub x_i: FE,

--- a/src/protocols/thresholdsig/zilliqa_schnorr.rs
+++ b/src/protocols/thresholdsig/zilliqa_schnorr.rs
@@ -30,6 +30,7 @@ use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
 use curv::cryptographic_primitives::hashing::traits::Hash;
 pub use curv::cryptographic_primitives::secret_sharing::feldman_vss::VerifiableSS;
 pub use curv::{BigInt, FE, GE};
+pub use curv::arithmetic::traits::Converter;
 
 const SECURITY: usize = 256;
 
@@ -57,6 +58,13 @@ pub struct KeyGenMessage3 {
     pub secret_share: FE,  // different per party, thus not a broadcast message
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SignMessage1 {
+    pub message: BigInt,
+    pub local_sig: LocalSig,  // different per party, thus not a broadcast message
+}
+
+
 #[derive(Debug)]
 pub struct Parameters {
     pub threshold: usize,   //t
@@ -67,6 +75,13 @@ pub struct Parameters {
 pub struct SharedKeys {
     pub y: GE,
     pub x_i: FE,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Share {
+    pub id: String,
+    pub shared_key: SharedKeys,
+    pub vss_scheme_vec: Vec<VerifiableSS>,
 }
 
 impl Keys {
@@ -187,6 +202,7 @@ impl Keys {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, Copy)]
 pub struct LocalSig {
     gamma_i: FE,
     e: FE,
@@ -278,7 +294,7 @@ impl LocalSig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Signature {
     pub s: FE,
     pub e: FE,


### PR DESCRIPTION
Support of new types and trait implementations to make wrapper implementations more straight forward. 
Wrapper implementations take this repo and wrap it with the needed multi-party communication.
Changes specifically refer to Zilliqa Schnorr.